### PR TITLE
feat: Add metadata and time-based filtering

### DIFF
--- a/minirag_app/minirag/base.py
+++ b/minirag_app/minirag/base.py
@@ -43,6 +43,9 @@ class QueryParam:
     history_turns: int = (
         3  # Number of complete conversation turns (user-assistant pairs) to consider
     )
+    metadata_filter: Optional[dict] = None
+    start_time: Optional[str] = None
+    end_time: Optional[str] = None
 
 
 @dataclass

--- a/minirag_app/minirag/minirag.py
+++ b/minirag_app/minirag/minirag.py
@@ -432,6 +432,13 @@ class MiniRAG:
             input = list(set(clean_text(doc) for doc in input))
             contents = {compute_mdhash_id(doc, prefix="doc-"): doc for doc in input}
 
+        if metadatas:
+            contents_with_meta = {
+                id_: (doc, meta) for id_, doc, meta in zip(ids, input, metadatas)
+            }
+        else:
+            contents_with_meta = {}
+
         unique_contents = {
             id_: content
             for content, id_ in {
@@ -505,7 +512,7 @@ class MiniRAG:
                     compute_mdhash_id(dp["content"], prefix="chunk-"): {
                         **dp,
                         "full_doc_id": doc_id,
-                        "metadata": status_doc.metadata,
+                        "metadata": status_doc.metadata or {},
                     }
                     for dp in self.chunking_func(
                         status_doc.content,
@@ -517,7 +524,7 @@ class MiniRAG:
                 await asyncio.gather(
                     self.chunks_vdb.upsert(chunks),
                     self.full_docs.upsert(
-                        {doc_id: {"content": status_doc.content, "metadata": status_doc.metadata}}
+                        {doc_id: {"content": status_doc.content, "metadata": status_doc.metadata or {}}}
                     ),
                     self.text_chunks.upsert(chunks),
                 )

--- a/minirag_app/minirag/operate.py
+++ b/minirag_app/minirag/operate.py
@@ -491,8 +491,11 @@ async def _build_local_query_context(
     query_param: QueryParam,
 ):
     results = await entities_vdb.query(
-        query, top_k=query_param.top_k, metadata_filter=query_param.metadata_filter,
-        start_time=query_param.start_time, end_time=query_param.end_time
+        query,
+        top_k=query_param.top_k,
+        metadata_filter=query_param.metadata_filter,
+        start_time=query_param.start_time,
+        end_time=query_param.end_time,
     )
 
     if not len(results):
@@ -766,8 +769,11 @@ async def _build_global_query_context(
     query_param: QueryParam,
 ):
     results = await relationships_vdb.query(
-        keywords, top_k=query_param.top_k, metadata_filter=query_param.metadata_filter,
-        start_time=query_param.start_time, end_time=query_param.end_time
+        keywords,
+        top_k=query_param.top_k,
+        metadata_filter=query_param.metadata_filter,
+        start_time=query_param.start_time,
+        end_time=query_param.end_time,
     )
 
     if not len(results):
@@ -1094,8 +1100,11 @@ async def naive_query(
 ):
     use_model_func = global_config["llm_model_func"]
     results = await chunks_vdb.query(
-        query, top_k=query_param.top_k, metadata_filter=query_param.metadata_filter,
-        start_time=query_param.start_time, end_time=query_param.end_time
+        query,
+        top_k=query_param.top_k,
+        metadata_filter=query_param.metadata_filter,
+        start_time=query_param.start_time,
+        end_time=query_param.end_time,
     )
     if not len(results):
         return PROMPTS["fail_response"], []
@@ -1285,8 +1294,11 @@ async def _build_mini_query_context(
     for ent in ent_from_query:
         ent_from_query_dict[ent] = []
         results_node = await entity_name_vdb.query(
-            ent, top_k=query_param.top_k, metadata_filter=query_param.metadata_filter,
-            start_time=query_param.start_time, end_time=query_param.end_time
+            ent,
+            top_k=query_param.top_k,
+            metadata_filter=query_param.metadata_filter,
+            start_time=query_param.start_time,
+            end_time=query_param.end_time,
         )
         # results_node の例（distance付き）
         # [{'entity_name': '"映画"', 'distance': 0.85}, {'entity_name': '"散歩"', 'distance': 0.72}, ...]
@@ -1343,7 +1355,8 @@ async def _build_mini_query_context(
         originalquery,
         top_k=len(ent_from_query) * query_param.top_k,
         metadata_filter=query_param.metadata_filter,
-        start_time=query_param.start_time, end_time=query_param.end_time
+        start_time=query_param.start_time,
+        end_time=query_param.end_time,
     )
     goodedge = []
     badedge = []
@@ -1400,7 +1413,8 @@ async def _build_mini_query_context(
         originalquery,
         top_k=int(query_param.top_k / 2),
         metadata_filter=query_param.metadata_filter,
-        start_time=query_param.start_time, end_time=query_param.end_time
+        start_time=query_param.start_time,
+        end_time=query_param.end_time,
     )
     chunks_ids = [r["id"] for r in results]
     final_chunk_id = kwd2chunk(


### PR DESCRIPTION
This commit introduces several new features to the MiniRAG system, allowing for more advanced filtering capabilities during queries.

The following filters have been added to the `QueryParam` dataclass:
- `metadata_filter`: A dictionary to filter documents based on their metadata.
- `start_time`: An ISO 8601 formatted string to filter documents created after a certain time.
- `end_time`: An ISO 8601 formatted string to filter documents created before a certain time.

These filters can be used in combination to perform more targeted searches.

The implementation involved changes in the following files:
- `minirag_app/minirag/base.py`: Added the new filter parameters to the `QueryParam` dataclass and `metadata` to the `DocProcessingStatus` dataclass.
- `minirag_app/minirag/kg/postgres_impl.py`: Updated the `PGVectorStorage.query` method to build a SQL query that includes `WHERE` clauses for the new filters. Also updated the `upsert` methods and table definitions to handle metadata.
- `minirag_app/minirag/operate.py`: Updated the query functions to pass the filter parameters to the vector storage query methods.
- `minirag_app/minirag/minirag.py`: Updated the document ingestion pipeline to handle `metadatas` and propagate them to the chunks.